### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
       - name: Gather repository metadata
         id: repo
-        uses: actions/github-script@7f4e771d2b3022fa3b8bac499d4a547619f3ab10
+        uses: actions/github-script@d50f485531ba88479582bc2da03ff424389af5c1
         with:
           script: |
             const repo = await github.rest.repos.get(context.repo)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -164,7 +164,7 @@ jobs:
       tags: ${{ steps.prep.outputs.tags }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -238,7 +238,7 @@ jobs:
     needs: [prepare]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -313,7 +313,7 @@ jobs:
     needs: [build]
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit
@@ -367,7 +367,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: cisagov/setup-env-github-action@a1913cd974407cd92d5b015342aa6d28d36539b8
       - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
       - id: setup-python
-        uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
         with:
           python-version: '3.10'
       # We need the Go version and Go cache location for the actions/cache step,
@@ -319,7 +319,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3df53dd32d858478710a6127bcd8b9d8b7182e16
       - id: setup-python
-        uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08
+        uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
         with:
           python-version: '3.10'
       - name: Cache testing environments

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@74b568e8591fbb3115c70f3436a0c6b0909a8504
+        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
         with:
           # TODO: change to 'egress-policy: block' after couple of runs
           egress-policy: audit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@3e7e3b32d0fb8283594bb0a76cc60a00918b0969
+        uses: github/codeql-action/init@c7f292ea4f542c473194b33813ccd4c207a6c725
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a
@@ -67,7 +67,7 @@ jobs:
       # Java). If this step fails, then you should remove it and run the build
       # manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@3e7e3b32d0fb8283594bb0a76cc60a00918b0969
+        uses: github/codeql-action/autobuild@c7f292ea4f542c473194b33813ccd4c207a6c725
 
       # ℹ️ Command-line programs to run using the OS shell. 📚
       # https://git.io/JvXDl
@@ -81,4 +81,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@3e7e3b32d0fb8283594bb0a76cc60a00918b0969
+        uses: github/codeql-action/analyze@c7f292ea4f542c473194b33813ccd4c207a6c725

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -55,6 +55,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         # v1.0.26
-        uses: github/codeql-action/upload-sarif@3e7e3b32d0fb8283594bb0a76cc60a00918b0969
+        uses: github/codeql-action/upload-sarif@c7f292ea4f542c473194b33813ccd4c207a6c725
         with:
           sarif_file: results.sarif

--- a/.yamllint
+++ b/.yamllint
@@ -5,5 +5,4 @@ rules:
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable
-  line-length:
-    allow-non-breakable-inline-mappings: true
+  line-length: disable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build
 ##
-FROM golang:1.18.4-bullseye AS build
+FROM golang:1.19.0-bullseye AS build
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go build -ldflags '-linkmode external -extldflags "-static"' \
 ##
 ## Deploy
 ##
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 # For a list of pre-defined annotation keys and value types see:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5
-	google.golang.org/grpc v1.48.0
+	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.0
 )
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5
 	google.golang.org/grpc v1.48.0
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.28.1
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -493,8 +493,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/go.sum
+++ b/src/go.sum
@@ -478,8 +478,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.48.0 h1:rQOsyJ/8+ufEDJd/Gdsz7HG220Mh9HAhFHRGnIjda0w=
-google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
+google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump github/codeql-action from 2.1.16 to 2.1.21 (#52) @dependabot
* Bump google.golang.org/grpc from 1.48.0 to 1.49.0 in /src (#51) @dependabot
* Bump actions/github-script from 7f4e771d2b3022fa3b8bac499d4a547619f3ab10 to 6.1.1 (#48) @dependabot
* Bump step-security/harden-runner from 1.4.4 to 1.4.5 (#47) @dependabot
* Bump alpine from 3.16.1 to 3.16.2 (#46) @dependabot
* Bump github.com/prometheus/client_golang from 1.12.2 to 1.13.0 in /src (#45) @dependabot
* Bump golang from 1.18.4-bullseye to 1.19.0-bullseye (#42) @dependabot
* Bump actions/setup-python from 4.1.0 to 4.2.0 (#41) @dependabot
* Bump google.golang.org/protobuf from 1.28.0 to 1.28.1 in /src (#39) @dependabot
